### PR TITLE
Service Map support

### DIFF
--- a/lib/aggregate-middleware.js
+++ b/lib/aggregate-middleware.js
@@ -47,6 +47,7 @@ exports.createAggregateSubsegment = (operation, aggregate, options) => {
     );
     subsegment.addAnnotation('model', aggregate.model().modelName);
     subsegment.addMetadata('operation', operation);
+    subsegment.namespace = 'remote';
     if (options && options.verbose) {
       subsegment.addMetadata('options', aggregate.options);
       subsegment.addMetadata('aggregate', JSON.stringify(aggregate));

--- a/lib/aggregate-middleware.js
+++ b/lib/aggregate-middleware.js
@@ -42,9 +42,8 @@ exports.registerAggregateMiddleware = (schema, options) => {
 exports.createAggregateSubsegment = (operation, aggregate, options) => {
   const parent = AWSXRay.getSegment();
   if (parent) {
-    const subsegment = parent.addNewSubsegment(
-      `${aggregate.model().modelName}-${operation}`
-    );
+    const subsegment = parent.addNewSubsegment('mongodb.aggregate');
+    subsegment.addAnnotation(`${aggregate.model().modelName}-${operation}`, 'aggregate');
     subsegment.addAnnotation('model', aggregate.model().modelName);
     subsegment.addMetadata('operation', operation);
     subsegment.namespace = 'remote';

--- a/lib/document-middleware.js
+++ b/lib/document-middleware.js
@@ -51,6 +51,7 @@ exports.createDocumentSubsegment = (operation, document, options) => {
 
     subsegment.addAnnotation('model', modelName);
     subsegment.addMetadata('operation', operation);
+    subsegment.namespace = 'remote';
     if (options && options.verbose) {
       subsegment.addMetadata('document', JSON.stringify(document));
     }

--- a/lib/document-middleware.js
+++ b/lib/document-middleware.js
@@ -47,8 +47,8 @@ exports.createDocumentSubsegment = (operation, document, options) => {
     const modelName =
       document.constructor.modelName ||
       `${document.constructor.name}-${document.constructor.path}`;
-    const subsegment = parent.addNewSubsegment(`${modelName}-${operation}`);
-
+    const subsegment = parent.addNewSubsegment('mongodb.document');
+    subsegment.addAnnotation(`${modelName}-${operation}`, 'document');
     subsegment.addAnnotation('model', modelName);
     subsegment.addMetadata('operation', operation);
     subsegment.namespace = 'remote';

--- a/lib/model-middleware.js
+++ b/lib/model-middleware.js
@@ -51,6 +51,7 @@ exports.createModelSubsegment = (operation, model) => {
     );
     subsegment.addAnnotation('model', model.modelName);
     subsegment.addMetadata('operation', operation);
+    subsegment.namespace = 'remote';
     logDebugSafe(
       `Mongoose-XRay: Opened Subsegment: ${subsegment.id} Parent Segment: ${parent.id}`
     );

--- a/lib/model-middleware.js
+++ b/lib/model-middleware.js
@@ -47,8 +47,9 @@ exports.createModelSubsegment = (operation, model) => {
   const parent = AWSXRay.getSegment();
   if (parent) {
     const subsegment = parent.addNewSubsegment(
-      `${model.modelName}-${operation}`
+      'mongodb.model'
     );
+    subsegment.addAnnotation(`${model.modelName}-${operation}`, 'model');
     subsegment.addAnnotation('model', model.modelName);
     subsegment.addMetadata('operation', operation);
     subsegment.namespace = 'remote';

--- a/lib/query-middleware.js
+++ b/lib/query-middleware.js
@@ -57,9 +57,8 @@ exports.registerQueryMiddleware = (schema, options) => {
 exports.createQuerySubsegment = (operation, query, options) => {
   const parent = AWSXRay.getSegment();
   if (parent) {
-    const subsegment = parent.addNewSubsegment(
-      `${query.model.modelName}-${operation}`
-    );
+    const subsegment = parent.addNewSubsegment('mongodb.query');
+    subsegment.addAnnotation(`${query.model.modelName}-${operation}`, 'query');
     subsegment.addAnnotation('model', query.model.modelName);
     subsegment.addMetadata('operation', operation);
     subsegment.namespace = 'remote';

--- a/lib/query-middleware.js
+++ b/lib/query-middleware.js
@@ -62,6 +62,7 @@ exports.createQuerySubsegment = (operation, query, options) => {
     );
     subsegment.addAnnotation('model', query.model.modelName);
     subsegment.addMetadata('operation', operation);
+    subsegment.namespace = 'remote';
     if (options && options.verbose) {
       subsegment.addMetadata(
         'filter',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-xray",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/integration/aggregate-middleware.spec.js
+++ b/test/integration/aggregate-middleware.spec.js
@@ -72,7 +72,7 @@ describe('Aggregate middleware applied to schema', function () {
     expect(addSubsegmentSpy).to.have.been.calledOnce();
     expect(addSubsegmentSpy.returnValues[0]).to.be.ok();
     const subsegment = addSubsegmentSpy.returnValues[0];
-    expect(subsegment.name).to.equal('xray-aggregate');
+    expect(subsegment.name).to.equal('mongodb.aggregate');
 
     expect(subsegment.annotations.model).to.equal('xray');
     expect(subsegment.metadata.default.operation).to.equal('aggregate');

--- a/test/unit/aggregate-middleware.spec.js
+++ b/test/unit/aggregate-middleware.spec.js
@@ -48,11 +48,15 @@ describe('Aggregate middleware', function () {
     };
     middleware.createAggregateSubsegment('aggregate', aggregate);
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModel-aggregate'
+      'mongodb.aggregate'
     );
     expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
       'model',
       'testModel'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModel-aggregate',
+      'aggregate'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',
@@ -73,7 +77,15 @@ describe('Aggregate middleware', function () {
       verbose: true,
     });
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModel-aggregate'
+      'mongodb.aggregate'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'model',
+      'testModel'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModel-aggregate',
+      'aggregate'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',

--- a/test/unit/aggregate-middleware.spec.js
+++ b/test/unit/aggregate-middleware.spec.js
@@ -58,6 +58,7 @@ describe('Aggregate middleware', function () {
       'operation',
       'aggregate'
     );
+    expect(subsegmentFake.namespace).to.equal('remote');
   });
 
   it('should create an aggregate subsegment with verbose option', function () {
@@ -78,6 +79,7 @@ describe('Aggregate middleware', function () {
       'operation',
       'aggregate'
     );
+    expect(subsegmentFake.namespace).to.equal('remote');
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'options',
       aggregate.options

--- a/test/unit/document-middleware.spec.js
+++ b/test/unit/document-middleware.spec.js
@@ -46,11 +46,15 @@ describe('Document middleware', function () {
     };
     middleware.createDocumentSubsegment('save', document);
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModel-save'
+      'mongodb.document'
     );
     expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
       'model',
       'testModel'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModel-save',
+      'document'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',
@@ -67,11 +71,15 @@ describe('Document middleware', function () {
     };
     middleware.createDocumentSubsegment('save', document);
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModel-some-path-save'
+      'mongodb.document'
     );
     expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
       'model',
       'testModel-some-path'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModel-some-path-save',
+      'document'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',
@@ -91,7 +99,11 @@ describe('Document middleware', function () {
       verbose: true,
     });
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModel-save'
+      'mongodb.document'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModel-save',
+      'document'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',

--- a/test/unit/document-middleware.spec.js
+++ b/test/unit/document-middleware.spec.js
@@ -56,6 +56,7 @@ describe('Document middleware', function () {
       'operation',
       'save'
     );
+    expect(subsegmentFake.namespace).to.equal('remote');
   });
 
   it('should create a document subsegment with name and path if no model name is present', function () {
@@ -76,6 +77,8 @@ describe('Document middleware', function () {
       'operation',
       'save'
     );
+
+    expect(subsegmentFake.namespace).to.equal('remote');
   });
 
   it('should create a document subsegment with verbose option', function () {
@@ -98,5 +101,6 @@ describe('Document middleware', function () {
       'document',
       JSON.stringify(document)
     );
+    expect(subsegmentFake.namespace).to.equal('remote');
   });
 });

--- a/test/unit/model-middleware.spec.js
+++ b/test/unit/model-middleware.spec.js
@@ -50,5 +50,6 @@ describe('Model middleware', function () {
       'operation',
       'insertMany'
     );
+    expect(subsegmentFake.namespace).to.equal('remote');
   });
 });

--- a/test/unit/model-middleware.spec.js
+++ b/test/unit/model-middleware.spec.js
@@ -40,11 +40,15 @@ describe('Model middleware', function () {
     };
     middleware.createModelSubsegment('insertMany', model);
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModelName-insertMany'
+      'mongodb.model'
     );
     expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
       'model',
       'testModelName'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModelName-insertMany',
+      'model'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',

--- a/test/unit/query-middleware.spec.js
+++ b/test/unit/query-middleware.spec.js
@@ -47,7 +47,15 @@ describe('Query middleware', function () {
     };
     middleware.createQuerySubsegment('find', query);
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModel-find'
+      'mongodb.query'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'model',
+      'testModel'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModel-find',
+      'query'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',
@@ -70,11 +78,15 @@ describe('Query middleware', function () {
       verbose: true,
     });
     expect(segmentFake.addNewSubsegment).to.have.been.calledOnceWith(
-      'testModel-find'
+      'mongodb.query'
     );
     expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
       'model',
       'testModel'
+    );
+    expect(subsegmentFake.addAnnotation).to.have.been.calledWith(
+      'testModel-find',
+      'query'
     );
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'operation',

--- a/test/unit/query-middleware.spec.js
+++ b/test/unit/query-middleware.spec.js
@@ -53,6 +53,7 @@ describe('Query middleware', function () {
       'operation',
       'find'
     );
+    expect(subsegmentFake.namespace).to.equal('remote');
   });
 
   it('should create a query subsegment with verbose option', function () {
@@ -79,6 +80,7 @@ describe('Query middleware', function () {
       'operation',
       'find'
     );
+    expect(subsegmentFake.namespace).to.equal('remote');
     expect(subsegmentFake.addMetadata).to.have.been.calledWith(
       'filter',
       query.getFilter()


### PR DESCRIPTION
### Why
In order to obtain aggregated execution time of external services/function calls (such as queries to a remotely hosted MongoDB service), these services/function calls must be included in the Service Map. The Service Map is where we will be able to view the average execution times and latency histogram. 

### Changes
In order to get an external service/function call onto the service map, we can set the `namespace` of a subsegment as `remote`. 
1. Added `namespace` prop to all subsegments with the value `remote`
2. Changed the names of each subsegment so that they are consistent across all calls. This will ensure the Service Map only has 1 node for all queries rather than 1 node for every combination of models + queries.
3. Added new annotation with the previous subsegment name